### PR TITLE
Show multiple devices in the treeview, and group ProgramBlocks and Da…

### DIFF
--- a/CodeGeneratorOpenness/cFunctionGroups.cs
+++ b/CodeGeneratorOpenness/cFunctionGroups.cs
@@ -18,24 +18,32 @@ namespace CodeGeneratorOpenness
 {
     class cFunctionGroups
     {
-        public void LoadTreeView(TreeView Tree, PlcSoftware Software)
+        public void ClearTreeView(TreeView Tree)
         {
             Tree.Nodes.Clear();
+        }
 
+        public void LoadTreeView(TreeView Tree, PlcSoftware Software)
+        {
             // start update treeview
             Tree.BeginUpdate();
 
             // add root node
             TreeNode root = new TreeNode(Software.Name);
-            root.Tag = Software.BlockGroup;
             Tree.Nodes.Add(root);
 
-            AddPlcBlocks(Software.BlockGroup, root);
+            // Add Program Blocks
+            TreeNode programBlocks = new TreeNode("Program Blocks");
+            programBlocks.Tag = Software.BlockGroup;
+            root.Nodes.Add(programBlocks);
+
+            AddPlcBlocks(Software.BlockGroup, programBlocks);
+            programBlocks.Expand();
 
             // add data types
-            TreeNode dataTypes = new TreeNode("Data types");
+            TreeNode dataTypes = new TreeNode("PLC Data types");
             dataTypes.Tag = Software.TypeGroup;
-            Tree.Nodes.Add(dataTypes);
+            root.Nodes.Add(dataTypes);
 
             AddPlcTypes(Software.TypeGroup, dataTypes);
             dataTypes.Expand();

--- a/CodeGeneratorOpenness/frmMainForm.cs
+++ b/CodeGeneratorOpenness/frmMainForm.cs
@@ -107,6 +107,8 @@ namespace CodeGeneratorOpenness
 
             Application.DoEvents();
 
+            groups.ClearTreeView(treeView1);
+
             // search through devices
             foreach (Device device in project.Devices)
             {


### PR DESCRIPTION
Hi,

This change enables projects with multiple (PLC) devices, all devices are shown in the treeview. A "Program Blocks" node is added under the device name to include alle program blocks, and "Data Types" is also added under the device.

regards,
Peter