### PR TITLE
Fix bug with date in filename (fails on format dd/mm/yyyy)

### DIFF
--- a/CodeGeneratorOpenness/frmMainForm.cs
+++ b/CodeGeneratorOpenness/frmMainForm.cs
@@ -903,7 +903,7 @@ namespace CodeGeneratorOpenness
                         {
                             string fPath = Application.StartupPath + "\\Export\\plcType_" +
                                 block.Name + "_" +
-                                block.ModifiedDate.ToShortDateString() +
+                                block.ModifiedDate.ToString("yyyyMMdd") +
                                 ".xml";
                             fPath = GetNextFileName(fPath);
 


### PR DESCRIPTION
Putting the date in the filename with ToShortDateString() fails if the date format contains a forward slash.